### PR TITLE
fix(logging): 🐛 redundant exit call

### DIFF
--- a/cmd/appstore/main.go
+++ b/cmd/appstore/main.go
@@ -83,8 +83,7 @@ func main() {
 	// Start server
 	listenAddr := fmt.Sprintf(":%s", cfg.ListenPort)
 	log.Printf("API server starting on %s in %s mode", listenAddr, cfg.GinMode)
-	if err := router.Run(listenAddr); err != nil {
-		log.Fatalf("Failed to run server: %v", err)
-		os.Exit(1)
-	}
+       if err := router.Run(listenAddr); err != nil {
+               log.Fatalf("Failed to run server: %v", err)
+       }
 }


### PR DESCRIPTION
## Summary
- remove unnecessary `os.Exit(1)` after `log.Fatalf`

## Testing
- `go vet ./...` *(fails: go.mod requires go >= 1.24.0)*
- `go build ./...` *(fails: go.mod requires go >= 1.24.0)*

------
https://chatgpt.com/codex/tasks/task_e_6841304b4670832fb5400e0951df6d00